### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Data/Decimal.js
+++ b/src/Data/Decimal.js
@@ -7,7 +7,7 @@ exports.fromInt = function(x) {
   return new Decimal(x);
 };
 
-exports["fromString'"] = function(nothing) {
+exports.fromStringImpl = function(nothing) {
   return function(just) {
     return function(str) {
       try {

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -60,7 +60,7 @@ foreign import fromNumber ∷ Number → Decimal
 -- | Converts a Decimal to a Number, possibly resulting in loss of precision.
 foreign import toNumber ∷ Decimal → Number
 
-foreign import fromString' ∷ ∀ a. Maybe a → (a → Maybe a) → String → Maybe Decimal
+foreign import fromStringImpl ∷ ∀ a. Maybe a → (a → Maybe a) → String → Maybe Decimal
 
 -- | Parse a string into a `Decimal`, assuming a decimal representation. Returns
 -- | `Nothing` if the parse fails.
@@ -73,7 +73,7 @@ foreign import fromString' ∷ ∀ a. Maybe a → (a → Maybe a) → String →
 -- | fromString "0.12301928309128183579487598149533"
 -- | ```
 fromString ∷ String → Maybe Decimal
-fromString = fromString' Nothing Just
+fromString = fromStringImpl Nothing Just
 
 foreign import dEquals ∷ Decimal → Decimal → Boolean
 


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.