### PR TITLE
Update decimal.js and add `clamp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "decimal.js": "7.1.1"
+    "decimal.js": "10.3.1"
   }
 }

--- a/src/Data/Decimal.js
+++ b/src/Data/Decimal.js
@@ -100,6 +100,14 @@ exports.dCompare = function(x) {
   };
 };
 
+exports.clamp = function(min) {
+  return function(max) {
+    return function(x) {
+      return x.clamp(min, max);
+    };
+  }
+};
+
 exports.abs = function(x) {
   return x.abs();
 };

--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -20,6 +20,7 @@ module Data.Decimal
   , atan2
   , atanh
   , ceil
+  , clamp
   , cos
   , cosh
   , exp
@@ -163,6 +164,9 @@ foreign import atanh ∷ Decimal → Decimal
 
 -- | Rounded to next whole number in the direction of `+inf`.
 foreign import ceil ∷ Decimal → Decimal
+
+-- | Clamp a number to the range delineated by the first two parameters.
+foreign import clamp ∷ Decimal -> Decimal -> Decimal -> Decimal
 
 -- | Cosine.
 foreign import cos ∷ Decimal → Decimal

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
-import Prelude hiding (min, max)
-import Data.Decimal (Decimal, abs, fromInt, fromNumber, pow, fromString,
+import Prelude hiding (clamp, min, max)
+import Data.Decimal (Decimal, abs, clamp, fromInt, fromNumber, pow, fromString,
                      toNumber, toString, toFixed, acos, acosh, asin, asinh, atan, atanh,
                      atan2, ceil, cos, cosh, exp, floor, ln, log10, max,
                      min, modulo, round, truncated, sin, sinh, sqrt, tan, tanh, e, pi, gamma,
@@ -115,6 +115,10 @@ main = do
 
   log "Absolute value"
   quickCheck $ \(TestDecimal x) → abs x == if x > zero then x else (-x)
+
+  log "clamp"
+  assert $ clamp three four one == three
+  assert $ clamp zero two zero == zero
 
   log "Other functions"
   testFn acos M.acos


### PR DESCRIPTION
https://mikemcl.github.io/decimal.js/#Dsum was also added in decimal.js 10.3.0; do we want to add it too?