### PR TITLE
Add `DivisionRing` and `Field` instances for `Decimal`

### DIFF
--- a/src/Data/Decimal.purs
+++ b/src/Data/Decimal.purs
@@ -134,6 +134,9 @@ instance euclideanRingDecimal ∷ EuclideanRing Decimal where
   mod _ _ = zero
   degree _ = one
 
+instance DivisionRing Decimal where
+  recip = dDiv one
+
 -- | Round to the given number of significant digits.
 foreign import toSignificantDigits ∷ Int → Decimal → Decimal
 


### PR DESCRIPTION
See https://github.com/sharkdp/purescript-decimals/issues/5#issuecomment-369847210.

There's no need to explicitly define a `Field` instance:

> This module also defines a single `Field` instance for any type which has both `EuclideanRing` and `DivisionRing` instances.

Source: https://pursuit.purescript.org/packages/purescript-prelude/5.0.1/docs/Data.Field#t:Field

It's probably a good idea to merge https://github.com/sharkdp/purescript-decimals/pull/14 before this, because of the omitted instance name.

Should I also add tests; if so, how?