### PR TITLE
Remove `psci-support` dependency from `spago.dhall`

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -7,7 +7,6 @@
   , "maybe"
   , "numbers"
   , "prelude"
-  , "psci-support"
   , "quickcheck"
   ]
 , packages = ./packages.dhall


### PR DESCRIPTION
`spago repl` automatically depends on `psci-support` as of Spago 0.20.5.
