### PR TITLE
Update Bower dependencies for PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/bower.json
+++ b/bower.json
@@ -17,12 +17,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-maybe": "^5.0.0"
+    "purescript-maybe": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^5.0.0",
-    "purescript-assert": "^5.0.0",
-    "purescript-quickcheck": "^7.0.0",
-    "purescript-numbers": "^8.0.0"
+    "purescript-psci-support": "^6.0.0",
+    "purescript-assert": "^6.0.0",
+    "purescript-quickcheck": "^8.0.0",
+    "purescript-numbers": "^9.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220429/packages.dhall
-        sha256:03c682bff56fc8f9d8c495ffcc6f524cbd3c89fe04778f965265c08757de8c9d
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220503/packages.dhall
+        sha256:847d49acea4803c3d42ef46114053561e91840e35ede29f0a8014d09d47cd8df
 
 in  upstream


### PR DESCRIPTION
This follows up on #16 by also updating the Bower dependencies so this can be published to Pursuit.